### PR TITLE
Fix Exception for 'unsupported listener implementation'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 		<module>spring-domain-events-jackson</module>
 		<module>spring-domain-events-tests</module>
 		<module>spring-domain-events-starter</module>
+		<module>spring-domain-events-mongodb</module>
 	</modules>
 
 	<build>

--- a/readme.adoc
+++ b/readme.adoc
@@ -16,7 +16,7 @@ This allows us to re-publish the events to transactional listeners that either h
 
 == Building blocks of the prototype
 
-* The `EventPublicationRegistry` -- the core interface to register publications and mark them completed. It allows different implementations (JPA, JDBC).
+* The `EventPublicationRegistry` -- the core interface to register publications and mark them completed. It allows different implementations (JPA, JDBC, MongoDB).
 * The `EventSerializer` -- a component to serialize the actual domain event so that it can be kept around in the publication. Again, to allow pluggable implementations (Jackson etc.)
 * `PersistentApplicationEventMulticaster` -- a replacement for Spring's default `ApplicationEventMulticaster` that stores publications via the `EventPublicationRegistry`.
 * `CompletionRegisteringBeanPostProcessor` -- a `BeanPostProcessor` that wraps `@TransactionalEventListener` instances with an interceptor to mark publications as completed.
@@ -27,4 +27,5 @@ This allows us to re-publish the events to transactional listeners that either h
 * `core` -- multicaster implementation, general and configuration infrastructure and SPI interfaces.
 * `jackson` -- a rudimentary Jackson-based `EventSerializer` implementation.
 * `jpa` -- a JPA-based `EventPublicationRegistry`.
+* `mongodb` -- a MongoDB based `EventPublicationRegistry`
 * `test` -- a sample integration test featuring two successful and one failing listener to show the registry exposes  the publication of the failed listener after the failure.

--- a/spring-domain-events-core/src/main/java/org/springframework/events/config/EventPublicationConfiguration.java
+++ b/spring-domain-events-core/src/main/java/org/springframework/events/config/EventPublicationConfiguration.java
@@ -23,22 +23,24 @@ import org.springframework.events.EventPublicationRegistry;
 import org.springframework.events.support.CompletionRegisteringBeanPostProcessor;
 import org.springframework.events.support.MapEventPublicationRegistry;
 import org.springframework.events.support.PersistentApplicationEventMulticaster;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * @author Oliver Drotbohm
  */
 @Configuration(proxyBeanMethods = false)
 class EventPublicationConfiguration {
-
-	@Bean
-	PersistentApplicationEventMulticaster applicationEventMulticaster(ObjectProvider<EventPublicationRegistry> registry) {
-
-		return new PersistentApplicationEventMulticaster(
-				() -> registry.getIfAvailable(() -> new MapEventPublicationRegistry()));
-	}
-
-	@Bean
-	static CompletionRegisteringBeanPostProcessor bpp(ObjectFactory<EventPublicationRegistry> store) {
-		return new CompletionRegisteringBeanPostProcessor(() -> store.getObject());
-	}
+    
+    @Bean
+    PersistentApplicationEventMulticaster applicationEventMulticaster(ObjectProvider<EventPublicationRegistry> registry,
+            TransactionTemplate transactionTemplate) {
+        
+        return new PersistentApplicationEventMulticaster(
+                () -> registry.getIfAvailable(() -> new MapEventPublicationRegistry()), transactionTemplate);
+    }
+    
+    @Bean
+    static CompletionRegisteringBeanPostProcessor bpp(ObjectFactory<EventPublicationRegistry> store) {
+        return new CompletionRegisteringBeanPostProcessor(() -> store.getObject());
+    }
 }

--- a/spring-domain-events-core/src/main/java/org/springframework/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-domain-events-core/src/main/java/org/springframework/events/support/PersistentApplicationEventMulticaster.java
@@ -179,8 +179,15 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 	@Override
 	public void afterSingletonsInstantiated() {
 
+	    boolean noIncompletePublications = true;
 		for (EventPublication publication : registry.get().findIncompletePublications()) {
+		    noIncompletePublications = false;
+		    log.info("Incomplete event publication (event: {}) Invoking listener {}", publication.getEvent(), publication.getTargetIdentifier());
 			invokeTargetListener(publication);
+		}
+		
+		if (noIncompletePublications) {
+		    log.info("No incomplete event publications to re-execute");
 		}
 	}
 

--- a/spring-domain-events-core/src/main/java/org/springframework/events/support/PersistentApplicationEventMulticaster.java
+++ b/spring-domain-events-core/src/main/java/org/springframework/events/support/PersistentApplicationEventMulticaster.java
@@ -172,7 +172,16 @@ public class PersistentApplicationEventMulticaster extends AbstractApplicationEv
 
 		for (ApplicationListener listener : getApplicationListeners()) {
 
-			if (publication.isIdentifiedBy(PublicationTargetIdentifier.forListener(listener))) {
+		    /*
+		     *  Ensure listener is transactional event listener. Otherwise
+		     *  PublicationTargetIdentifier.forListener(listener) may throw an exception
+		     *  for listeners that are no instance of ApplicationListenerMethodAdapter.
+		     *  
+		     *  This additional check is perfectly fine as we only save EventPublications
+		     *  for transactional listeners anyway (see: multicastEvent(...)).
+		     */
+			if (isTransactionalApplicationEventListener(listener)
+			        && publication.isIdentifiedBy(PublicationTargetIdentifier.forListener(listener))) {
 
 				executeListenerWithCompletion(publication, listener);
 				return;

--- a/spring-domain-events-mongodb/pom.xml
+++ b/spring-domain-events-mongodb/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>de.olivergierke.events</groupId>
+		<artifactId>spring-domain-events</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<name>Spring Domain Events - MongoDB-based registry</name>
+
+	<artifactId>spring-domain-events-mongodb</artifactId>
+	
+	<dependencies>
+    
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>spring-domain-events-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <!--  MongoDB -->
+        
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+        </dependency>
+        
+    </dependencies>
+</project>

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/CustomizedFindBySerializedEventAndListenerId.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/CustomizedFindBySerializedEventAndListenerId.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import java.util.Optional;
+
+/**
+ * @author Felix Jordan
+ */
+public interface CustomizedFindBySerializedEventAndListenerId {
+    
+    /**
+     * Return the {@link MongoEventPublication} for the given serialized event
+     * and listener identifier.
+     * 
+     * @param event must not be {@literal null}.
+     * @param listenerId must not be {@literal null}.
+     * @return
+     */
+    Optional<MongoEventPublication> findBySerializedEventAndListenerId(Object event, String listenerId);
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/CustomizedFindBySerializedEventAndListenerIdImpl.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/CustomizedFindBySerializedEventAndListenerIdImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import java.util.Optional;
+
+import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.convert.MongoWriter;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.util.ClassTypeInformation;
+import org.springframework.stereotype.Component;
+
+/**
+ * Provides a custom implementation of
+ * {@link MongoEventPublicationRepository#findBySerializedEventAndListenerId(Object, String)}.<br>
+ * <br>
+ * The query needs to do an exact match of the given event and the stored
+ * serializedEvent. The serializedEvent in the database contain a '_class'
+ * field to store type information. But the normal Spring Data
+ * implementation of the query method does not include this field in the
+ * query.<br>
+ * <br>
+ * In this implementation we force the field to be included by passing
+ * {@code ClassTypeInformation.OBJECT} to the
+ * {@link MongoWriter#convertToMongoType(Object, org.springframework.data.util.TypeInformation)}
+ * method. Since Object type will always differ from the actual event type the
+ * {@code MongoWriter} adds type information ('_class' field) per definition.
+ * 
+ * @author Felix Jordan
+ */
+@Component
+public class CustomizedFindBySerializedEventAndListenerIdImpl implements CustomizedFindBySerializedEventAndListenerId {
+    
+    private MongoOperations mongoOperations;
+    private MongoWriter<?> writer;
+    
+    public CustomizedFindBySerializedEventAndListenerIdImpl(MongoOperations mongoOperations, MongoWriter<?> writer) {
+        this.mongoOperations = mongoOperations;
+        this.writer = writer;
+    }
+    
+    @Override
+    public Optional<MongoEventPublication> findBySerializedEventAndListenerId(Object event, String listenerId) {
+        
+        /*
+         *  Pass typeInformation for java.lang.Object here. This forces MongoDB to add '_class' attribute
+         *  to query which is necessary for exact object match. 
+         */
+        Object convertedEvent = this.writer.convertToMongoType(event, ClassTypeInformation.OBJECT);
+        
+        Query query = new Query();
+        query.addCriteria(Criteria.where("serializedEvent").is(convertedEvent));
+        query.addCriteria(Criteria.where("listenerId").is(listenerId));
+        
+        return this.mongoOperations.query(MongoEventPublication.class).matching(query).one();
+    }
+    
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublication.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublication.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import java.time.Instant;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Felix Jordan
+ */
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor(onConstructor_={@PersistenceConstructor}, access = AccessLevel.PRIVATE)
+public class MongoEventPublication {
+    
+    private final @Id ObjectId id;
+    private final Instant publicationDate;
+    private final String listenerId;
+    /*
+     * We do not limit ourselves here to String representation so that
+     * also the possibility exists to store events as embedded documents.
+     */
+    private final Object serializedEvent;
+    /*
+     * When using Class<?> we would need to register a custom converter
+     * which causes some trouble since there can be only one MongoCustomConversions bean.
+     */
+    private final String eventType;
+    
+    private Instant completionDate;
+    
+    @Builder
+    static MongoEventPublication of(Instant publicationDate, String listenerId, Object serializedEvent,
+            String eventType) {
+        return new MongoEventPublication(ObjectId.get(), publicationDate, listenerId, serializedEvent,
+                eventType);
+    }
+    
+    MongoEventPublication markCompleted() {
+
+        this.completionDate = Instant.now();
+        return this;
+    }
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationConfiguration.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.events.EventSerializer;
+import org.springframework.events.mongodb.support.NoEventSerializerBeanCondition;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Felix Jordan
+ */
+@Configuration(proxyBeanMethods = false)
+@RequiredArgsConstructor
+@EnableMongoRepositories
+public class MongoEventPublicationConfiguration {
+    
+    private final MongoEventPublicationRepository repository;
+    private final ObjectFactory<EventSerializer> serializer;
+    
+    @Bean
+    public MongoEventPublicationRegistry mongoEventPublicationRegistry() {
+        return new MongoEventPublicationRegistry(repository, serializer.getObject());
+    }
+    
+    @Bean
+    @Conditional(NoEventSerializerBeanCondition.class)
+    public EventSerializer mongoEventSerializer() {
+        return new MongoEventSerializer();
+    }
+    
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationRegistry.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationRegistry.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.PayloadApplicationEvent;
+import org.springframework.events.CompletableEventPublication;
+import org.springframework.events.EventPublication;
+import org.springframework.events.EventPublicationRegistry;
+import org.springframework.events.EventSerializer;
+import org.springframework.events.PublicationTargetIdentifier;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MongoDB based {@link EventPublicationRegistry}.
+ * 
+ * @author Felix Jordan
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class MongoEventPublicationRegistry implements EventPublicationRegistry, DisposableBean {
+    
+    private final @NonNull MongoEventPublicationRepository events;
+    private final @NonNull EventSerializer serializer;
+    
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.events.EventPublicationRegistry#store(java.lang.Object, java.util.Collection)
+     */
+    @Override
+    public void store(Object event, Collection<ApplicationListener<?>> listeners) {
+        
+        listeners.stream() //
+                .map(it -> PublicationTargetIdentifier.forListener(it)) //
+                .map(it -> CompletableEventPublication.of(event, it)) //
+                .map(this::map) //
+                .forEach(it -> events.save(it));
+        
+        log.info("Stored event publication successfully");
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.events.EventPublicationRegistry#findIncompletePublications()
+     */
+    @Override
+    public Iterable<EventPublication> findIncompletePublications() {
+        
+        List<EventPublication> result = events.findByCompletionDateIsNull().stream() //
+                .map(it -> MongoEventPublicationAdapter.of(it, serializer)) //
+                .collect(Collectors.toList());
+        
+        return result;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.events.EventPublicationRegistry#markCompleted(java.lang.Object, org.springframework.events.ListenerId)
+     */
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markCompleted(Object event, PublicationTargetIdentifier listener) {
+        
+        Assert.notNull(event, "Domain event must not be null!");
+        Assert.notNull(listener, "Listener identifier must not be null!");
+        
+        /*
+         *  TODO Move this code to a higher layer (PersistentApplicationEventMulticaster or
+         *  EventPublicationRegistry), since this problem is not specific for MongoDB.
+         */
+        /*
+         * They stored event is always the actual event, so we have to extract the payload in case we
+         * have a PayloadApplicationEvent here!
+         */
+        Object actualEvent = event instanceof PayloadApplicationEvent
+                ? ((PayloadApplicationEvent<?>) event).getPayload()
+                : event;
+        
+        events.findBySerializedEventAndListenerId(serializer.serialize(actualEvent), listener.toString()) //
+                .map(MongoEventPublicationRegistry::logCompleted) //
+                .ifPresent(it -> events.save(it.markCompleted()));
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see org.springframework.beans.factory.DisposableBean#destroy()
+     */
+    @Override
+    public void destroy() throws Exception {
+        
+        List<MongoEventPublication> outstandingPublications = events.findByCompletionDateIsNull();
+        
+        if (outstandingPublications.isEmpty()) {
+            
+            log.debug("No publications outstanding!");
+            return;
+        }
+        
+        log.debug("Shutting down with the following publications left unfinished:");
+        
+        outstandingPublications
+                .forEach(it -> log.debug("\t{} - {} - {}", it.getId(), it.getEventType(), it.getListenerId()));
+    }
+    
+    private MongoEventPublication map(EventPublication publication) {
+        
+        MongoEventPublication result = MongoEventPublication.builder() //
+                .eventType(publication.getEvent().getClass().getName()) //
+                .publicationDate(publication.getPublicationDate()) //
+                .listenerId(publication.getTargetIdentifier().toString()) //
+                .serializedEvent(serializer.serialize(publication.getEvent())) //
+                .build();
+        
+        log.debug("Registering publication of {} with id {} for {}.", //
+                result.getEventType(), result.getId(), result.getListenerId());
+        
+        return result;
+    }
+    
+    private static MongoEventPublication logCompleted(MongoEventPublication publication) {
+        
+        log.debug("Marking publication of event {} with id {} to listener {} completed.", //
+                publication.getEventType(), publication.getId(), publication.getListenerId());
+        
+        return publication;
+    }
+    
+    @EqualsAndHashCode
+    @RequiredArgsConstructor(staticName = "of")
+    static class MongoEventPublicationAdapter implements EventPublication {
+        
+        private final MongoEventPublication publication;
+        private final EventSerializer serializer;
+        
+        /*
+         * (non-Javadoc)
+         * @see org.springframework.events.EventPublication#getEvent()
+         */
+        @Override
+        public Object getEvent() {
+            
+            
+            return serializer.deserialize(publication.getSerializedEvent(), getEventType());
+        }
+        
+        private Class<?> getEventType() {
+            String eventClassName = publication.getEventType();
+            try {
+                /*
+                 * TODO Do we get some problems with class loaders here?
+                 */
+                return Class.forName(eventClassName);
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("Cannot find event class: " + eventClassName, e);
+            }
+        }
+        
+        /*
+         * (non-Javadoc)
+         * @see org.springframework.events.EventPublication#getListenerId()
+         */
+        @Override
+        public PublicationTargetIdentifier getTargetIdentifier() {
+            return PublicationTargetIdentifier.of(publication.getListenerId());
+        }
+        
+        /*
+         * (non-Javadoc)
+         * @see org.springframework.events.EventPublication#getPublicationDate()
+         */
+        @Override
+        public Instant getPublicationDate() {
+            return publication.getPublicationDate();
+        }
+        
+    }
+    
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationRepository.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventPublicationRepository.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository to store {@link MongoEventPublication}s.
+ * 
+ * @author Felix Jordan
+ */
+@Repository
+public interface MongoEventPublicationRepository
+        extends MongoRepository<MongoEventPublication, ObjectId>, CustomizedFindBySerializedEventAndListenerId {
+    
+    /**
+     * Returns all {@link MongoEventPublication} that have not been completed
+     * yet.
+     */
+    List<MongoEventPublication> findByCompletionDateIsNull();
+    
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventSerializer.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/MongoEventSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb;
+
+import org.springframework.events.EventSerializer;
+
+/**
+ * @author Felix Jordan
+ */
+public class MongoEventSerializer implements EventSerializer {
+    
+    /*
+     * (non-Javadoc)
+     * @see de.olivergierke.events.EventSerializer#serialize(java.lang.Object)
+     */
+    @Override
+    public Object serialize(Object event) {
+        return event;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * @see de.olivergierke.events.EventSerializer#deserialize(java.lang.Object, java.lang.Class)
+     */
+    @Override
+    public Object deserialize(Object serialized, Class<?> type) {
+        if (!type.isAssignableFrom(serialized.getClass())) {
+            throw new IllegalArgumentException("Invalid serialized event class: " + serialized.getClass()
+                    + "(expecting: " + type + ")");
+        }
+        return serialized;
+    }
+    
+}

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/package-info.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.lang.NonNullApi
+package org.springframework.events.mongodb;

--- a/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/support/NoEventSerializerBeanCondition.java
+++ b/spring-domain-events-mongodb/src/main/java/org/springframework/events/mongodb/support/NoEventSerializerBeanCondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.events.mongodb.support;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.events.EventSerializer;
+
+/**
+ * {@link Condition} to check whether an {@link EventSerializer} bean exists.
+ * 
+ * @author Felix Jordan
+ */
+public class NoEventSerializerBeanCondition implements Condition {
+    
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return context.getBeanFactory().getBeansOfType(EventSerializer.class).isEmpty();
+    }
+}

--- a/spring-domain-events-mongodb/src/main/resources/META-INF/spring.factories
+++ b/spring-domain-events-mongodb/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.events.config.EventPublicationConfigurationExtension=org.springframework.events.mongodb.MongoEventPublicationConfiguration

--- a/spring-domain-events-tests/src/test/java/example/events/InfrastructureConfiguration.java
+++ b/spring-domain-events-tests/src/test/java/example/events/InfrastructureConfiguration.java
@@ -26,7 +26,9 @@ import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.Database;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Configuration(proxyBeanMethods = false)
 @EnableTransactionManagement
@@ -55,5 +57,10 @@ class InfrastructureConfiguration {
 	@Bean
 	JpaTransactionManager transactionManager(EntityManagerFactory factory) {
 		return new JpaTransactionManager(factory);
+	}
+	
+	@Bean
+	TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+	    return new TransactionTemplate(transactionManager);
 	}
 }


### PR DESCRIPTION
During event publication in `multicastEvent(...)` method `PublicationTargetIdentifier.forListener(listener)` will throw an Exception for all listeners that are not an instance of 'ApplicationListenerMethodAdapter'.

This makes the project unusable in spring boot projects with additional libraries such as spring-web or spring-data-mongodb. These projects have a number of ApplicationEventListeners that are not an instance of the required class.

While one (probably very extensive) option may be to add support for all these listeners, I think a better approach is to ignore these listeners in the first place. The events we want to store reliable are the domain events and no internal Spring events. And domain events are handled in `@TransactionalEventListener`s.
Apart from that transactional listeners are anyway the only ones for which an EventPublication is stored in the registry.

My solution uses EventPublications for all transactional listeners and for other listeners it simply calls `listener.onApplicationEvent(event);`

I'm looking forward to your feedback.